### PR TITLE
Fixes action on staging (correct use of b/e latest image)

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -56,7 +56,7 @@ env:
   #
   #   For Jobs conditional on the presence of a secret see this Gist...
   #   https://gist.github.com/jonico/24ffebee6d2fa2e679389fac8aef50a3
-  BE_IMAGE_TAG: stable
+  BE_IMAGE_TAG: latest
   BE_NAMESPACE: xchem
   FE_IMAGE_TAG: latest
   FE_NAMESPACE: xchem


### PR DESCRIPTION
The `staging` build action incorrectly uses the b/e `stable` tag. In this change the correct b/e tag is used (e.g. `latest`).

This fixes the peculiar behaviour when f/e changes are committed to its staging branch (and it picks up a potentially older `stable` implementation).